### PR TITLE
[avclj] Misnamed option

### DIFF
--- a/src/avclj.clj
+++ b/src/avclj.clj
@@ -24,10 +24,9 @@ user> (defn img-tensor
                       :uint8))
 #'user/img-tensor
 nil
-user> (let [encoder-name \"mp4\"
-            output-fname \"file://test/data/test-video.mp4\"]
+user> (let [output-fname \"file://test/data/test-video.mp4\"]
         (with-open [encoder (avclj/make-video-encoder 256 256 output-fname
-                                                      {:encoder-name encoder-name})]
+                                                      {:encoder-name-or-id \"mpeg4\"})]
           (dotimes [iter 125]
             (avclj/encode-frame! encoder (img-tensor [256 256 3] iter)))))
 nil

--- a/test/avclj_test.clj
+++ b/test/avclj_test.clj
@@ -32,11 +32,10 @@
 
 
 (deftest encode-demo
-  (let [encoder-name "mp4"
-        output-fname "file://test/data/test-video.mp4"]
+  (let [output-fname "file://test/data/test-video.mp4"]
     (.delete (java.io.File. "test/data/test-video.mp4"))
     (with-open [encoder (avclj/make-video-encoder 256 256 output-fname
-                                                  {:encoder-name encoder-name})]
+                                                  {:encoder-name-or-id "mpeg4"})]
       (dotimes [iter 125]
         (avclj/encode-frame! encoder (img-tensor [256 256 3] iter))))
     (is (.exists (java.io.File. "test/data/test-video.mp4")))))


### PR DESCRIPTION
 - It appears this fn expects `:encoder-name-or-id`, not `:encoder-name`.

c.f. https://github.com/cnuernber/avclj/blob/7bbb14ee7fdfbc8083a7fcb7eb9233bd2d710459/src/avclj.clj#L211