### PR TITLE
Specify full classname for library

### DIFF
--- a/native_test/avclj/libavclj.clj
+++ b/native_test/avclj/libavclj.clj
@@ -78,5 +78,5 @@
         #'close-encoder {:rettype :int64
                          :argtypes [['encoder :int64]]}
         }
-       'avljc/LibAVClj nil)))
+       'avljc.LibAVClj nil)))
   )


### PR DESCRIPTION
Using `'avljc/LibAVClj` as the classname arg will ignore the namespace part of the symbol and instead use something like `(str (name *ns*) "." (name classname))`.

It might even be better to specify the classname as `avclj.LibAVClj.cinterface` or another name that doesn't clash with the defining namespace. 